### PR TITLE
Clean up Spell methods

### DIFF
--- a/lib/intervallum/module.scroll.rb
+++ b/lib/intervallum/module.scroll.rb
@@ -1,61 +1,58 @@
 module Scroll
+  @month_numbers_to_names = {
+    1 => 'January',
+    2 => 'February',
+    3 => 'March',
+    4 => 'April',
+    5 => 'May',
+    6 => 'June',
+    7 => 'July',
+    8 => 'August',
+    9 => 'September',
+    10 => 'October',
+    11 => 'November',
+    12 => 'December'
+  }
+
+  @month_names_to_numbers = @month_numbers_to_names.invert
+
+  @days_in_month = {
+    1 => 31,
+    2 => 28,
+    3 => 31,
+    4 => 30,
+    5 => 31,
+    6 => 30,
+    7 => 31,
+    8 => 31,
+    9 => 30,
+    10 => 31,
+    11 => 30,
+    12 => 31
+  }
+
   def self.get_month_name(number)
-    months = {
-      1 => 'January',
-      2 => 'February',
-      3 => 'March',
-      4 => 'April',
-      5 => 'May',
-      6 => 'June',
-      7 => 'July',
-      8 => 'August',
-      9 => 'September',
-      10 => 'October',
-      11 => 'November',
-      12 => 'December'
-    }
-    months[number]
+    @month_numbers_to_names[number]
   end
 
   def self.get_month_number(name)
-    name.downcase!
-    months = {
-      'january' => 1,
-      'february' => 2,
-      'march' => 3,
-      'april' => 4,
-      'may' => 5,
-      'june' => 6,
-      'july' => 7,
-      'august' => 8,
-      'september' => 9,
-      'october' => 10,
-      'november' => 11,
-      'december' => 12
-    }
-    months[name]
+    @month_names_to_numbers[name.capitalize]
   end
 
-  def self.last_day_of_month?(month_number, day)
-    months = {
-      1 => 31,
-      2 => 28,
-      3 => 31,
-      4 => 30,
-      5 => 31,
-      6 => 30,
-      7 => 31,
-      8 => 31,
-      9 => 30,
-      10 => 31,
-      11 => 30,
-      12 => 31
-    }
-    day.to_i == months[month_number]
+  def self.last_day_of_month?(month, day)
+    if month.is_a? Integer
+      day.to_i == @days_in_month[month]
+    else
+      day.to_i == @days_in_month[self.get_month_number(month)]
+    end
   end
 
   def self.first_of_the_year?(month, day)
-    self.get_month_name(month.to_i) == 'January' && day.to_i == 1
+    if month.is_a? Integer
+      month == 1 && day.to_i == 1
+    else
+      self.get_month_number(month) == 1 && day.to_i == 1
+    end
   end
 
   def self.first_of_the_month?(month, day)
@@ -63,19 +60,30 @@ module Scroll
   end
 
   def self.last_day_of_the_year?(month, day)
-    day = day.to_i
-    month == 12 && day == 31
+    if month.is_a? Integer
+      month == 12 && day.to_i == 31
+    else
+      self.get_month_number(month) == 12 && day.to_i == 31
+    end
   end
 
   def self.last_month_of_year?(month)
-    month == 12
+    if month.is_a? Integer
+      month == 12
+    else
+      self.get_month_number(month) == 12
+    end
   end
 
   def self.last_of_the_month?(month, day)
-    self.last_day_of_month[month.to_i] == day
+    self.last_day_of_month?(month, day)
   end
 
   def self.first_month_of_the_year?(month)
-    month == 1
+    if month.is_a? Integer
+      month == 1
+    else
+      self.get_month_number(month) == 1
+    end
   end
 end


### PR DESCRIPTION
Cleaned up the Spell module a bit.

1. Hashes are now module-wide, so they don't get redeclared each time one of the methods is called.
2. Updated the methods to support both Integer and String representations of a month (`1` and `'January'`, etc.).
3. Also removed the dangerous `name.downcase!`, which was modifying the variable that was originally passed in.

I didn't bump the gem version or anything, thought I'd leave that to you.